### PR TITLE
gemspec: Avoid a warning by require English

### DIFF
--- a/abanalyzer.gemspec
+++ b/abanalyzer.gemspec
@@ -1,6 +1,7 @@
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'abanalyzer/version'
 require 'date'
+require 'English'
 
 Gem::Specification.new do |s|
   s.name = 'abanalyzer'


### PR DESCRIPTION
  - $INPUT_RECORD_SEPARATOR is defined in `English`

Test output currently includes:

> /home/travis/build/bmuller/abanalyzer/abanalyzer.gemspec:13: warning: global variable `$INPUT_RECORD_SEPARATOR' not initialized