### PR TITLE
Gemfile: refer to https source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
This PR refers to RubyGems.org via HTTPS.